### PR TITLE
Fix for the Remote Code Execution (RCE) Vulnerability

### DIFF
--- a/bin/meta-git-clone
+++ b/bin/meta-git-clone
@@ -7,53 +7,58 @@ const getMetaFile = require('get-meta-file');
 const path = require('path');
 const program = require('commander');
 const util = require('util');
+const isGitUrl = require('is-git-url');
 
 if (!process.argv[2] || process.argv[2] === '--help')
   return console.log(`\n  usage:\n\n    meta git clone <metaRepoUrl>\n`);
 
 const repoUrl = process.argv[2] === 'blank' ? process.argv[3] : process.argv[2];
 
-const dirname = path.basename(repoUrl).replace('.git', '');
+if (isGitUrl(repoUrl)) {
+  const dirname = path.basename(repoUrl).replace('.git', '');
+  
+  console.log(`meta git cloning into \'${repoUrl}\' at ${dirname}`);
 
-console.log(`meta git cloning into \'${repoUrl}\' at ${dirname}`);
-
-exec({ cmd: `git clone ${repoUrl} ${dirname}`, displayDir: dirname }, (err, result) => {
-  if (err) throw err;
-
-  const newDir = path.resolve(dirname);
-
-  debug(`chdir to ${newDir}`);
-
-  process.chdir(newDir);
-
-  const meta = getMetaFile();
-
-  const projects = meta.projects;
-  const folders = Object.keys(projects);
-
-  var folder = null;
-
-  function child(err) {
+  exec({ cmd: `git clone ${repoUrl} ${dirname}`, displayDir: dirname }, (err, result) => {
     if (err) throw err;
 
-    if (!folders.length) return 0;
+    const newDir = path.resolve(dirname);
 
-    folder = folders.pop();
+    debug(`chdir to ${newDir}`);
 
-    const gitUrl = projects[folder];
+    process.chdir(newDir);
 
-    exec(
-      {
-        cmd: `git clone ${gitUrl} ${folder}`,
-        displayDir: path.join(newDir, folder),
-      },
-      err => {
-        if (err) throw err;
+    const meta = getMetaFile();
 
-        child();
-      }
-    );
-  }
+    const projects = meta.projects;
+    const folders = Object.keys(projects);
 
-  child();
-});
+    var folder = null;
+
+    function child(err) {
+      if (err) throw err;
+
+      if (!folders.length) return 0;
+
+      folder = folders.pop();
+
+      const gitUrl = projects[folder];
+
+      exec(
+        {
+          cmd: `git clone ${gitUrl} ${folder}`,
+          displayDir: path.join(newDir, folder),
+        },
+        err => {
+          if (err) throw err;
+
+          child();
+        }
+      );
+    }
+
+    child();
+  });
+} else {
+  console.log(`\nERROR: The given Git Repo URL is not valid\n`);
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "commander": "^2.9.0",
     "debug": "^4.1.0",
     "get-meta-file": "^1.0.0",
+    "is-git-url": "^1.0.0",
     "loop": "^3.0.6",
     "meta-exec": "^1.0.0",
     "meta-loop": "^1.0.0"


### PR DESCRIPTION
This fix validates the given input and validates whether it's a git repo URL or not. So the command will only execute when the input is a valid Git Repo URL.

As this application can run on different OS platforms (_Bash Terminals, Windows Terminal etc_), character escaping is a hassle and there will be ways to bypass it so I implemented Git Repo URL validation with **[is-git-url](https://www.npmjs.com/package/is-git-url)**. :)

**Fixed!** :+1: 
